### PR TITLE
Implemented a 2phase rebase

### DIFF
--- a/contracts/mocks/MockXCAmple.sol
+++ b/contracts/mocks/MockXCAmple.sol
@@ -1,17 +1,17 @@
 pragma solidity 0.6.4;
 
 contract MockXCAmple {
-    uint256 private _totalSupply;
+    uint256 private _totalAMPLSupply;
     event LogRebase(uint256 epoch, uint256 totalSupply);
     event MintCalled(address who, uint256 value);
     event BurnCalled(address who, uint256 value);
 
-    function totalSupply() public view returns (uint256) {
-        return _totalSupply;
+    function totalAMPLSupply() public view returns (uint256) {
+        return _totalAMPLSupply;
     }
 
-    function rebase(uint256 epoch, uint256 totalSupply_) external returns (uint256) {
-        emit LogRebase(epoch, totalSupply_);
+    function rebase(uint256 epoch, uint256 totalAMPLSupply) external returns (uint256) {
+        emit LogRebase(epoch, totalAMPLSupply);
     }
 
     function mint(address who, uint256 value) external {
@@ -22,7 +22,7 @@ contract MockXCAmple {
         emit BurnCalled(who, value);
     }
 
-    function updateTotalSupply(uint256 totalSupply_) external {
-        _totalSupply = totalSupply_;
+    function updateTotalSupply(uint256 totalAMPLSupply) external {
+        _totalAMPLSupply = totalAMPLSupply;
     }
 }

--- a/test/xc-ampleforth/xc_controller_rebase.js
+++ b/test/xc-ampleforth/xc_controller_rebase.js
@@ -4,7 +4,7 @@ const { expect } = require('chai');
 let accounts,
   deployer,
   bridge,
-  bridgeAddress,
+  rebaseCaller,
   controller,
   mockToken,
   mockRebaseRelayer;
@@ -13,8 +13,7 @@ async function setupContracts () {
   accounts = await ethers.getSigners();
   deployer = accounts[0];
   bridge = accounts[1];
-
-  bridgeAddress = await bridge.getAddress();
+  rebaseCaller = accounts[2];
 
   mockToken = await (await ethers.getContractFactory('MockXCAmple'))
     .connect(deployer)
@@ -54,34 +53,22 @@ async function increaseTime (seconds) {
   ]);
 }
 
-describe('XCAmpleController:rebase:accessControl', async () => {
-  beforeEach('setup XCAmpleController contract', setupContracts);
-
-  it('should NOT be callable by non-bridge', async function () {
-    await expect(
-      controller.connect(deployer).rebase(2, 1000),
-    ).to.be.revertedWith('XCAmpleController: Bridge gateway not whitelisted');
-  });
-
-  it('should be callable by bridge', async function () {
-    await expect(controller.connect(bridge).rebase(2, 1000)).to.not.be.reverted;
-  });
-});
-
 describe('XCAmpleController:rebase:epoch', async () => {
   beforeEach('setup XCAmpleController contract', setupContracts);
 
   describe('when epoch is not new', function () {
     it('should revert', async function () {
+      await controller.connect(bridge).reportRebase(1, 1000);
       await expect(
-        controller.connect(bridge).rebase(1, 1000),
+        controller.connect(rebaseCaller).rebase(),
       ).to.be.revertedWith('XCAmpleController: Epoch not new');
     });
   });
 
   describe('when epoch is new', function () {
     it('should NOT revert', async function () {
-      await expect(controller.connect(bridge).rebase(2, 1000)).to.not.be
+      await controller.connect(bridge).reportRebase(2, 1000);
+      await expect(controller.connect(rebaseCaller).rebase()).to.not.be
         .reverted;
     });
   });
@@ -94,45 +81,56 @@ describe('XCAmpleController:rebase', async () => {
   });
 
   it('should update epoch', async function () {
-    await controller.connect(bridge).rebase(2, 50626634);
+    await controller.connect(bridge).reportRebase(2, 50626634);
+    await controller.connect(rebaseCaller).rebase();
     expect(await controller.globalAmpleforthEpoch()).to.eq(2);
   });
 
   it('should update lastRebaseTimestampSec', async function () {
     const t1 = await controller.lastRebaseTimestampSec();
     await increaseTime(3600);
-    await controller.connect(bridge).rebase(2, 50626634);
+    await controller.connect(bridge).reportRebase(2, 50626634);
+    await controller.connect(rebaseCaller).rebase();
     const t2 = await controller.lastRebaseTimestampSec();
     await increaseTime(3600);
-    await controller.connect(bridge).rebase(3, 50626634);
+    await controller.connect(bridge).reportRebase(3, 50626634);
+    await controller.connect(rebaseCaller).rebase();
     const t3 = await controller.lastRebaseTimestampSec();
     expect(t2.sub(t1)).to.gte(3600);
     expect(t3.sub(t2)).to.gte(3600);
   });
 
   it('should invoke rebase on the token contract', async function () {
-    await expect(controller.connect(bridge).rebase(2, 50626634))
+    await controller.connect(bridge).reportRebase(2, 50626634);
+    await expect(controller.connect(rebaseCaller).rebase())
       .to.emit(mockToken, 'LogRebase')
       .withArgs(2, 50626634);
   });
 
   it('should log Rebase with supply delta', async function () {
-    const r = await controller.connect(bridge).rebase(2, 50626634);
+    await controller.connect(bridge).reportRebase(2, 50626634);
+    const r = await controller.connect(rebaseCaller).rebase();
     const t = await controller.lastRebaseTimestampSec();
     expect((async () => r)())
-      .to.emit(controller, 'GatewayRebase')
-      .withArgs(bridgeAddress, 2, 10634511, t);
+      .to.emit(controller, 'LogRebase')
+      .withArgs(2, 10634511, t);
   });
 
   it('should NOT allow successive invocation', async function () {
-    await controller.connect(bridge).rebase(2, 50626634);
-    await expect(
-      controller.connect(bridge).rebase(2, 50626634),
-    ).to.be.revertedWith('XCAmpleController: Epoch not new');
+    await controller.connect(bridge).reportRebase(2, 50626634);
+    await controller.connect(rebaseCaller).rebase();
+
+    await controller.connect(bridge).reportRebase(2, 50626634);
+    await expect(controller.connect(rebaseCaller).rebase()).to.be.revertedWith(
+      'XCAmpleController: Epoch not new',
+    );
+
     await increaseTime(3600);
-    await expect(
-      controller.connect(bridge).rebase(2, 50626634),
-    ).to.be.revertedWith('XCAmpleController: Epoch not new');
+
+    await controller.connect(bridge).reportRebase(2, 50626634);
+    await expect(controller.connect(rebaseCaller).rebase()).to.be.revertedWith(
+      'XCAmpleController: Epoch not new',
+    );
   });
 });
 
@@ -143,11 +141,12 @@ describe('XCAmpleController:rebase:contraction', async () => {
   });
 
   it('should log Rebase with supply delta', async function () {
-    const r = await controller.connect(bridge).rebase(2, 22692382);
+    await controller.connect(bridge).reportRebase(2, 22692382);
+    const r = await controller.connect(rebaseCaller).rebase();
     const t = await controller.lastRebaseTimestampSec();
     expect((async () => r)())
-      .to.emit(controller, 'GatewayRebase')
-      .withArgs(bridgeAddress, 2, -17299741, t);
+      .to.emit(controller, 'LogRebase')
+      .withArgs(2, -17299741, t);
   });
 });
 
@@ -158,11 +157,12 @@ describe('XCAmpleController:rebase:noChange', async () => {
   });
 
   it('should log Rebase with supply delta', async function () {
-    const r = await controller.connect(bridge).rebase(2, 39992123);
+    await controller.connect(bridge).reportRebase(2, 39992123);
+    const r = await controller.connect(rebaseCaller).rebase();
     const t = await controller.lastRebaseTimestampSec();
     expect((async () => r)())
-      .to.emit(controller, 'GatewayRebase')
-      .withArgs(bridgeAddress, 2, 0, t);
+      .to.emit(controller, 'LogRebase')
+      .withArgs(2, 0, t);
   });
 });
 
@@ -174,7 +174,8 @@ describe('XCAmpleController:rebase:rebaseRelayerSuccess', async () => {
   });
 
   it('should execute rebase', async function () {
-    await expect(controller.connect(bridge).rebase(2, 1000)).to.not.be.reverted;
+    await controller.connect(bridge).reportRebase(2, 1000);
+    await expect(controller.connect(rebaseCaller).rebase()).to.not.be.reverted;
   });
 });
 
@@ -186,7 +187,8 @@ describe('XCAmpleController:rebase:rebaseRelayerFailure', async () => {
   });
 
   it('should revert rebase', async function () {
-    await expect(controller.connect(bridge).rebase(2, 1000)).to.be.reverted;
+    await controller.connect(bridge).reportRebase(2, 1000);
+    await expect(controller.connect(rebaseCaller).rebase()).to.be.reverted;
   });
 });
 
@@ -198,6 +200,7 @@ describe('XCAmpleController:rebase:rebaseRelayerFailure', async () => {
   });
 
   it('should revert rebase', async function () {
-    await expect(controller.connect(bridge).rebase(2, 1000)).to.be.reverted;
+    await controller.connect(bridge).reportRebase(2, 1000);
+    await expect(controller.connect(rebaseCaller).rebase()).to.be.reverted;
   });
 });


### PR DESCRIPTION
Gateway reports rebase and then rebase can be executed as a public function call.

The bridge transaction no longer reverts.