### PR TITLE
chain-bridge gateway contracts

### DIFF
--- a/contracts/bridge-gateways/chain-bridge/AMPLChainBridgeGateway.sol
+++ b/contracts/bridge-gateways/chain-bridge/AMPLChainBridgeGateway.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.6.12;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../../bridge-interfaces/IAmpleforthPolicy.sol";
+import "../../bridge-interfaces/ITokenVault.sol";
+import "../../bridge-interfaces/IBridgeGateway.sol";
+
+/**
+ * @title AMPLChainBridgeGateway: AMPL-ChainBridge Gateway Contract
+ * @dev This contract is deployed on the base chain (Ethereum).
+ *
+ *      It's a pass-through contract between the ChainBridge handler contract and
+ *      the Ampleforth policy and the Token vault.
+ *
+ *      The contract is owned by the ChainBridge handler contract.
+ *
+ *      When rebase is transmitted across the bridge, It checks the consistency of rebase data
+ *      from the ChainBridge handler contract with the recorded on-chain value.
+ *
+ *      When a sender initiates a cross-chain AMPL transfer from the
+ *      current chain (source chain) to a target chain through chain-bridge,
+ *      `validateAndLock` is executed.
+ *      It validates if total supply reported is consistent with the
+ *      recorded on-chain value and locks AMPLS in a token vault.
+ *
+ *      When a sender has initiated a cross-chain AMPL transfer from a source chain
+ *      to a recipient on the current chain (target chain),
+ *      chain-bridge executes the `unlock` function.
+ *      The amount of tokens to be unlocked to the recipient is calculated based on
+ *      the globalAMPLSupply on the source chain, at the time of transfer initiation
+ *      and the total ERC-20 AMPL supply on the current chain, at the time of unlock.
+ *
+ */
+contract AMPLChainBridgeGateway is IBridgeGateway, Ownable {
+    using SafeMath for uint256;
+
+    address public ampl;
+    address public policy;
+    address public vault;
+
+    /**
+     * @dev Validates if the data from the handler is consistent with the
+     *      recorded value on the current chain.
+     * @param globalAmpleforthEpoch Ampleforth monetary policy epoch.
+     * @param globalAMPLSupply AMPL ERC-20 total supply.
+     */
+    function validateRebaseReport(uint256 globalAmpleforthEpoch, uint256 globalAMPLSupply)
+        public
+        onlyOwner
+        returns (bool)
+    {
+
+        uint256 recordedGlobalAmpleforthEpoch = IAmpleforthPolicy(policy).epoch();
+        uint256 recordedGlobalAMPLSupply = IERC20(ampl).totalSupply();
+
+        require(
+            globalAmpleforthEpoch == recordedGlobalAmpleforthEpoch,
+            "AMPLChainBridgeGateway: epoch not consistent"
+        );
+        require(
+            globalAMPLSupply == recordedGlobalAMPLSupply,
+            "AMPLChainBridgeGateway: total supply not consistent"
+        );
+
+        emit XCRebaseReportOut(globalAmpleforthEpoch, globalAMPLSupply);
+
+        return true;
+    }
+
+    /**
+     * @dev Validates the data from the handler and transfers specified amount from
+     *      the sender's wallet and locks it in the vault contract.
+     * @param sender Address of the sender wallet on the base chain.
+     * @param recipientAddressInTargetChain Address of the recipient wallet in the target chain.
+     * @param amount Amount of tokens to be locked on the current chain (source chain).
+     * @param globalAMPLSupply AMPL ERC-20 total supply at the time of transfer locking.
+     */
+    function validateAndLock(
+        address sender,
+        address recipientAddressInTargetChain,
+        uint256 amount,
+        uint256 globalAMPLSupply
+    ) public onlyOwner returns (bool) {
+        uint256 recordedGlobalAMPLSupply = IERC20(ampl).totalSupply();
+
+        require(
+            globalAMPLSupply == recordedGlobalAMPLSupply,
+            "AMPLChainBridgeGateway: total supply not consistent"
+        );
+
+        ITokenVault(vault).lock(ampl, sender, amount);
+
+        emit XCTransferOut(sender, amount, recordedGlobalAMPLSupply);
+
+        return true;
+    }
+
+    /**
+     * @dev Calculates the amount of amples to be unlocked based on the share of total supply and
+     *      transfers it to the recipient.
+     * @param senderAddressInSourceChain Address of the sender wallet in the transaction originating chain.
+     * @param recipient Address of the recipient wallet in the current chain (target chain).
+     * @param amount Amount of tokens that were {locked/burnt} on the base chain.
+     * @param globalAMPLSupply AMPL ERC-20 total supply at the time of transfer.
+     */
+    function unlock(
+        address senderAddressInSourceChain,
+        address recipient,
+        uint256 amount,
+        uint256 globalAMPLSupply
+    ) public onlyOwner returns (bool) {
+        uint256 recordedGlobalAMPLSupply = IERC20(ampl).totalSupply();
+        uint256 unlockAmount = amount.mul(recordedGlobalAMPLSupply).div(globalAMPLSupply);
+
+        emit XCTransferIn(
+            recipient,
+            globalAMPLSupply,
+            unlockAmount,
+            recordedGlobalAMPLSupply
+        );
+
+        ITokenVault(vault).unlock(ampl, recipient, unlockAmount);
+
+        return true;
+    }
+
+    constructor(
+        address bridgeHandler,
+        address ampl_,
+        address policy_,
+        address vault_
+    ) public {
+        ampl = ampl_;
+        policy = policy_;
+        vault = vault_;
+
+        transferOwnership(bridgeHandler);
+    }
+}

--- a/contracts/bridge-gateways/chain-bridge/ChainBridgeXCAmpleGateway.sol
+++ b/contracts/bridge-gateways/chain-bridge/ChainBridgeXCAmpleGateway.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.6.12;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "../../bridge-interfaces/IBridgeGateway.sol";
+import "../../bridge-interfaces/IXCAmpleController.sol";
+import "../../bridge-interfaces/IXCAmple.sol";
+
+/**
+ * @title ChainBridgeXCAmpleGateway
+ * @dev This contract is deployed on the satellite EVM chains eg). tron, acala, near etc.
+ *
+ *      It's a pass-through contract between the ChainBridge handler contract and
+ *      the xc-ample controller contract.
+ *
+ *      When rebase is transmitted across the bridge,
+ *      It forwards the next rebase report to the xc-ample controller.
+ *
+ *      When a sender initiates a cross-chain AMPL transfer from a
+ *      source chain to a recipient on the current chain (target chain)
+ *      the xc-amples are mint into the recipient's wallet.
+ *      The amount of tokens to be mint is calculated based on the globalAMPLSupply
+ *      on a source chain at the time of transfer and the,
+ *      globalAMPLSupply recorded on the current chain at the time of minting.
+ *
+ *      When a sender initiates a cross-chain AMPL transfer from the current chain (source chain)
+ *      to a recipient on a target chain, chain-bridge executes the `validateAndBurn`.
+ *      It validates if the total supply reported is consistent with the recorded on-chain value
+ *      and burns xc-amples from the sender's wallet.
+ *
+ */
+contract ChainBridgeXCAmpleGateway is IBridgeGateway, Ownable {
+    using SafeMath for uint256;
+
+    address public xcAmpl;
+    address public xcController;
+
+    /**
+     * @dev Forwards the most recent rebase information from the bridge handler to the xc-ample controller.
+     * @param globalAmpleforthEpoch Ampleforth monetary policy epoch from the base chain.
+     * @param globalAMPLSupply AMPL ERC-20 total supply from the base chain.
+     */
+    function reportRebase(uint256 globalAmpleforthEpoch, uint256 globalAMPLSupply)
+        external
+        onlyOwner
+        returns (bool)
+    {
+        uint256 recordedGlobalAmpleforthEpoch = IXCAmpleController(xcController)
+            .globalAmpleforthEpoch();
+
+        uint256 recordedGlobalAMPLSupply = IXCAmple(xcAmpl).globalAMPLSupply();
+
+        emit XCRebaseReportIn(
+            globalAmpleforthEpoch,
+            globalAMPLSupply,
+            recordedGlobalAmpleforthEpoch,
+            recordedGlobalAMPLSupply
+        );
+
+        IXCAmpleController(xcController).reportRebase(globalAmpleforthEpoch, globalAMPLSupply);
+
+        return true;
+    }
+
+    /**
+     * @dev Calculates the amount of xc-amples to be mint based on the amount and the total supply
+     *      on the master chain when the transaction was initiated
+     *      and mints xc-amples to the recipient.
+     * @param senderAddressInSourceChain Address of the sender wallet in the transaction originating chain.
+     * @param recipient Address of the recipient wallet in the current chain (target chain).
+     * @param amount Amount of tokens that were {locked/burnt} on the source chain.
+     * @param globalAMPLSupply AMPL ERC-20 total supply at the time of transfer.
+     */
+    function mint(
+        address senderAddressInSourceChain,
+        address recipient,
+        uint256 amount,
+        uint256 globalAMPLSupply
+    ) external onlyOwner returns (bool) {
+
+        uint256 recordedGlobalAMPLSupply = IXCAmple(xcAmpl).globalAMPLSupply();
+        uint256 mintAmount = amount.mul(recordedGlobalAMPLSupply).div(globalAMPLSupply);
+
+        emit XCTransferIn(
+            recipient,
+            globalAMPLSupply,
+            mintAmount,
+            recordedGlobalAMPLSupply
+        );
+
+        IXCAmpleController(xcController).mint(recipient, mintAmount);
+
+        return true;
+    }
+
+    /**
+     * @dev Validates the data from the handler and burns specified amount from the sender's wallet.
+     * @param sender Address of the sender wallet on the source chain.
+     * @param recipientAddressInTargetChain Address of the recipient wallet in the target chain.
+     * @param amount Amount of tokens to be burnt on the current chain (source chain).
+     * @param globalAMPLSupply AMPL ERC-20 total supply at the time of transfer burning.
+     */
+    function validateAndBurn(
+        address sender,
+        address recipientAddressInTargetChain,
+        uint256 amount,
+        uint256 globalAMPLSupply
+    ) external onlyOwner returns (bool) {
+
+        uint256 recordedGlobalAMPLSupply = IXCAmple(xcAmpl).globalAMPLSupply();
+        require(
+            globalAMPLSupply == recordedGlobalAMPLSupply,
+            "ChainBridgeXCAmpleGateway: total supply not consistent"
+        );
+
+        IXCAmpleController(xcController).burn(sender, amount);
+
+        emit XCTransferOut(sender, amount, recordedGlobalAMPLSupply);
+
+        return true;
+    }
+
+    constructor(
+        address bridgeHandler,
+        address xcAmpl_,
+        address xcController_
+    ) public {
+        xcAmpl = xcAmpl_;
+        xcController = xcController_;
+
+        transferOwnership(bridgeHandler);
+    }
+}

--- a/contracts/bridge-interfaces/IAmpleforthPolicy.sol
+++ b/contracts/bridge-interfaces/IAmpleforthPolicy.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.6.12;
+
+interface IAmpleforthPolicy {
+    function epoch() external returns (uint256);
+}

--- a/contracts/bridge-interfaces/IBatchTxExecutor.sol
+++ b/contracts/bridge-interfaces/IBatchTxExecutor.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.6.12;
+
+interface IBatchTxExecutor {
+    function executeAll() external returns (bool);
+}

--- a/contracts/bridge-interfaces/IBridgeGateway.sol
+++ b/contracts/bridge-interfaces/IBridgeGateway.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.6.12;
+
+/*
+    INTERFACE NAMING CONVETION:
+
+    Base Chain: Ethereum; chain where actual AMPL tokens are locked/unlocked
+    Satellite Chain: (tron, acala, ..); chain where xc-ample tokens are mint/burnt
+
+    Source chain: Chain where a cross-chain transaction is initiated. (any chain ethereum, tron, acala ...)
+    Target chain: Chain where a cross-chain transaction is finalized. (any chain ethereum, tron, acala ...)
+
+    If a variable is prefixed with recorded: It refers to the existing value on the current-chain.
+    eg) When rebase is reported to tron through a bridge, globalAMPLSupply is the new value reported through the bridge and recordedGlobalAMPLSupply refers to the current value on tron.
+
+    On the Base chain:
+    * ampl.totalSupply is the globalAMPLSupply.
+
+    On Satellite chains:
+    * xcAmple.totalSupply returns the current supply of xc-amples in circulation
+    * xcAmple.globalAMPLSupply returns the chain's copy of the base chain's globalAMPLSupply.
+*/
+
+interface IBridgeGateway {
+    // Logged on the base chain gateway (ethereum) when rebase report is propagated out
+    event XCRebaseReportOut(
+        uint256 globalAmpleforthEpoch,          // epoch from the Ampleforth Monetary Policy on the base chain
+        uint256 globalAMPLSupply                // totalSupply of AMPL ERC-20 contract on the base chain
+    );
+
+    // Logged on the satellite chain gateway (tron, acala, near) when bridge reports most recent rebase
+    event XCRebaseReportIn(
+        uint256 globalAmpleforthEpoch,           // new value coming in from the base chain
+        uint256 globalAMPLSupply,                // new value coming in from the base chain
+        uint256 recordedGlobalAmpleforthEpoch,   // existing value on the satellite chain
+        uint256 recordedGlobalAMPLSupply         // existing value on the satellite chain
+    );
+
+    // Logged on source chain when cross-chain transfer is initiated
+    event XCTransferOut(
+        address sender,                          // user sending funds
+        uint256 amount,                          // amount to be locked/burnt
+        uint256 recordedGlobalAMPLSupply         // existing value on the current source chain
+    );
+
+    // Logged on target chain when cross-chain transfer is completed
+    event XCTransferIn(
+        address recipient,                       // user receiving funds
+        uint256 globalAMPLSupply,                // value on remote chain when transaction was initiated
+        uint256 amount,                          // amount to be unlocked/mint
+        uint256 recordedGlobalAMPLSupply         // existing value on the current target chain
+    );
+}

--- a/contracts/bridge-interfaces/ITokenVault.sol
+++ b/contracts/bridge-interfaces/ITokenVault.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.6.12;
+
+interface ITokenVault {
+    function lock(address token, address depositor, uint256 amount) external;
+
+    function unlock(address token, address recipient, uint256 amount) external;
+}

--- a/contracts/bridge-interfaces/IXCAmple.sol
+++ b/contracts/bridge-interfaces/IXCAmple.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.6.12;
+
+interface IXCAmple {
+    function globalAMPLSupply() external returns (uint256);
+
+    function mint(address who, uint256 value) external;
+
+    function burn(address who, uint256 value) external;
+
+    function rebase(uint256 globalAmpleforthEpoch, uint256 globalAMPLSupply) external returns (uint256);
+}

--- a/contracts/bridge-interfaces/IXCAmpleController.sol
+++ b/contracts/bridge-interfaces/IXCAmpleController.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.6.12;
+
+interface IXCAmpleController {
+    function globalAmpleforthEpoch() external returns (uint256);
+
+    function mint(address recipient, uint256 xcAmplAmount) external;
+
+    function burn(address depositor, uint256 xcAmplAmount) external;
+
+    function reportRebase(uint256 nextGlobalAmpleforthEpoch, uint256 nextGlobalAMPLSupply) external;
+}

--- a/test/bridge-gateways/chain-bridge/ampl_chain_brdige_gateway.js
+++ b/test/bridge-gateways/chain-bridge/ampl_chain_brdige_gateway.js
@@ -1,0 +1,316 @@
+const { ethers } = require('@nomiclabs/buidler');
+const { expect } = require('chai');
+
+let accounts,
+  deployer,
+  depositorAddress,
+  recipient,
+  recipientAddress,
+  bridge,
+  bridgeAddress,
+  ampl,
+  policy,
+  vault,
+  gateway;
+async function setupContracts () {
+  accounts = await ethers.getSigners();
+  deployer = accounts[0];
+  depositorAddress = await deployer.getAddress();
+  recipient = accounts[1];
+  recipientAddress = await recipient.getAddress();
+  bridge = accounts[2];
+  bridgeAddress = await bridge.getAddress();
+
+  ampl = await (await ethers.getContractFactory('MockAmpl'))
+    .connect(deployer)
+    .deploy();
+  policy = await (await ethers.getContractFactory('MockAmplPolicy'))
+    .connect(deployer)
+    .deploy();
+  vault = await (await ethers.getContractFactory('MockVault'))
+    .connect(deployer)
+    .deploy();
+
+  gateway = await (await ethers.getContractFactory('AMPLChainBridgeGateway'))
+    .connect(deployer)
+    .deploy(bridgeAddress, ampl.address, policy.address, vault.address);
+
+  await policy.updateEpoch(1);
+  await ampl.updateTotalSupply(50000);
+}
+
+describe('AMPLChainBridgeGateway:Initialization', () => {
+  before('setup AMPLChainBridgeGateway contract', setupContracts);
+
+  it('should initialize the references', async function () {
+    expect(await gateway.ampl()).to.eq(ampl.address);
+    expect(await gateway.policy()).to.eq(policy.address);
+    expect(await gateway.vault()).to.eq(vault.address);
+  });
+
+  it('should set the owner', async function () {
+    expect(await gateway.owner()).to.eq(bridgeAddress);
+  });
+});
+
+describe('AMPLChainBridgeGateway:validateRebaseReport:accessControl', () => {
+  before('setup AMPLChainBridgeGateway contract', setupContracts);
+
+  it('should NOT be callable by non-owner', async function () {
+    await expect(
+      gateway.connect(deployer).validateRebaseReport(1, 50000),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
+  it('should be callable by owner', async function () {
+    await expect(gateway.connect(bridge).validateRebaseReport(1, 50000)).to.not
+      .be.reverted;
+  });
+});
+
+describe('AMPLChainBridgeGateway:validateRebaseReport', () => {
+  before('setup AMPLChainBridgeGateway contract', setupContracts);
+
+  describe('when epoch is not consistent', async function () {
+    it('should revert', async function () {
+      await expect(
+        gateway.connect(bridge).validateRebaseReport(2, 50000),
+      ).to.be.revertedWith('AMPLChainBridgeGateway: epoch not consistent');
+    });
+  });
+
+  describe('when total supply is not consistent', async function () {
+    it('should revert', async function () {
+      await expect(
+        gateway.connect(bridge).validateRebaseReport(1, 50001),
+      ).to.be.revertedWith(
+        'AMPLChainBridgeGateway: total supply not consistent',
+      );
+    });
+  });
+});
+
+describe('AMPLChainBridgeGateway:validateRebaseReport', () => {
+  before('setup AMPLChainBridgeGateway contract', setupContracts);
+
+  it('should emit XCRebaseReportOut', async function () {
+    await expect(gateway.connect(bridge).validateRebaseReport(1, 50000))
+      .to.emit(gateway, 'XCRebaseReportOut')
+      .withArgs(1, 50000);
+  });
+});
+
+describe('AMPLChainBridgeGateway:validateAndLock:accessControl', () => {
+  before('setup AMPLChainBridgeGateway contract', async function () {
+    await setupContracts();
+  });
+
+  it('should NOT be callable by non-owner', async function () {
+    await expect(
+      gateway
+        .connect(deployer)
+        .validateAndLock(depositorAddress, recipientAddress, 1001, 50000),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
+  it('should be callable by owner', async function () {
+    await gateway
+      .connect(bridge)
+      .validateAndLock(depositorAddress, recipientAddress, 1001, 50000);
+
+    await expect(
+      gateway
+        .connect(bridge)
+        .validateAndLock(depositorAddress, recipientAddress, 1001, 50000),
+    ).to.not.be.reverted;
+  });
+});
+
+describe('AMPLChainBridgeGateway:validateAndLock', () => {
+  before('setup AMPLChainBridgeGateway contract', setupContracts);
+
+  describe('when total supply is not consistent', async function () {
+    it('should revert', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .validateAndLock(depositorAddress, recipientAddress, 1001, 50001),
+      ).to.be.revertedWith(
+        'AMPLChainBridgeGateway: total supply not consistent',
+      );
+    });
+  });
+});
+
+describe('AMPLChainBridgeGateway:validateAndLock', () => {
+  before('setup AMPLChainBridgeGateway contract', setupContracts);
+
+  it('should emit XCTransferOut', async function () {
+    await expect(
+      gateway
+        .connect(bridge)
+        .validateAndLock(depositorAddress, recipientAddress, 1001, 50000),
+    )
+      .to.emit(gateway, 'XCTransferOut')
+      .withArgs(depositorAddress, 1001, 50000);
+  });
+
+  it('should lock into vault', async function () {
+    await expect(
+      gateway
+        .connect(bridge)
+        .validateAndLock(depositorAddress, recipientAddress, 1001, 50000),
+    )
+      .to.emit(vault, 'Lock')
+      .withArgs(ampl.address, depositorAddress, 1001);
+  });
+});
+
+describe('AMPLChainBridgeGateway:unlock:accessControl', () => {
+  before('setup AMPLChainBridgeGateway contract', setupContracts);
+
+  it('should NOT be callable by non-owner', async function () {
+    await expect(
+      gateway
+        .connect(deployer)
+        .unlock(depositorAddress, recipientAddress, 1001, 50000),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
+  it('should be callable by owner', async function () {
+    await expect(
+      gateway
+        .connect(bridge)
+        .unlock(depositorAddress, recipientAddress, 1001, 50000),
+    ).to.not.be.reverted;
+  });
+});
+
+describe('AMPLChainBridgeGateway:unlock', () => {
+  before('setup AMPLChainBridgeGateway contract', setupContracts);
+
+  describe('when recorded supply = total supply', function () {
+    it('should emit XCTransferIn', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .unlock(depositorAddress, recipientAddress, 1001, 25000),
+      )
+        .to.emit(gateway, 'XCTransferIn')
+        .withArgs(recipientAddress, 25000, 2002, 50000);
+    });
+
+    it('should unlock from vault', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .unlock(depositorAddress, recipientAddress, 1001, 25000),
+      )
+        .to.emit(vault, 'Unlock')
+        .withArgs(ampl.address, recipientAddress, 2002);
+    });
+  });
+});
+
+describe('AMPLChainBridgeGateway:unlock', () => {
+  before('setup AMPLChainBridgeGateway contract', setupContracts);
+
+  describe('when recorded supply < total supply', function () {
+    it('should emit XCTransferIn', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .unlock(depositorAddress, recipientAddress, 1001, 100000),
+      )
+        .to.emit(gateway, 'XCTransferIn')
+        .withArgs(recipientAddress, 100000, 500, 50000);
+    });
+
+    it('should unlock from vault', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .unlock(depositorAddress, recipientAddress, 1001, 100000),
+      )
+        .to.emit(vault, 'Unlock')
+        .withArgs(ampl.address, recipientAddress, 500);
+    });
+  });
+});
+
+describe('AMPLChainBridgeGateway:unlock', () => {
+  before('setup AMPLChainBridgeGateway contract', setupContracts);
+
+  describe('when recorded supply > total supply', function () {
+    it('should emit XCTransferIn', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .unlock(depositorAddress, recipientAddress, 1001, 25000),
+      )
+        .to.emit(gateway, 'XCTransferIn')
+        .withArgs(recipientAddress, 25000, 2002, 50000);
+    });
+
+    it('should unlock from vault', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .unlock(depositorAddress, recipientAddress, 1001, 25000),
+      )
+        .to.emit(vault, 'Unlock')
+        .withArgs(ampl.address, recipientAddress, 2002);
+    });
+  });
+});
+
+describe('AMPLChainBridgeGateway:unlock', () => {
+  before('setup AMPLChainBridgeGateway contract', setupContracts);
+
+  describe('large numbers', function () {
+    const MAX_SUPPLY = ethers.BigNumber.from(2).pow(128).sub(1);
+    const HALF_MAX_SUPPLY = MAX_SUPPLY.div(2);
+    it('should unlock correct number of ampls', async function () {
+      await ampl.updateTotalSupply(HALF_MAX_SUPPLY);
+      await expect(
+        gateway
+          .connect(bridge)
+          .unlock(
+            depositorAddress,
+            recipientAddress,
+            '100000000000000000000',
+            MAX_SUPPLY,
+          ),
+      )
+        .to.emit(vault, 'Unlock')
+        .withArgs(ampl.address, recipientAddress, '49999999999999999999');
+
+      await ampl.updateTotalSupply(MAX_SUPPLY);
+      await expect(
+        gateway
+          .connect(bridge)
+          .unlock(
+            depositorAddress,
+            recipientAddress,
+            '100000000000000000000',
+            HALF_MAX_SUPPLY,
+          ),
+      )
+        .to.emit(vault, 'Unlock')
+        .withArgs(ampl.address, recipientAddress, '200000000000000000000');
+
+      await expect(
+        gateway
+          .connect(bridge)
+          .unlock(
+            depositorAddress,
+            recipientAddress,
+            '100000000000000000000',
+            MAX_SUPPLY,
+          ),
+      )
+        .to.emit(vault, 'Unlock')
+        .withArgs(ampl.address, recipientAddress, '100000000000000000000');
+    });
+  });
+});

--- a/test/bridge-gateways/chain-bridge/chain_bridge_xcampl_gateway.js
+++ b/test/bridge-gateways/chain-bridge/chain_bridge_xcampl_gateway.js
@@ -1,0 +1,303 @@
+const { ethers } = require('@nomiclabs/buidler');
+const { expect } = require('chai');
+
+let accounts,
+  deployer,
+  depositorAddress,
+  recipient,
+  recipientAddress,
+  bridge,
+  bridgeAddress,
+  xcAmpl,
+  xcController,
+  gateway;
+async function setupContracts () {
+  accounts = await ethers.getSigners();
+  deployer = accounts[0];
+  depositorAddress = await deployer.getAddress();
+  bridge = accounts[1];
+  bridgeAddress = await bridge.getAddress();
+  recipient = accounts[2];
+  recipientAddress = await recipient.getAddress();
+
+  xcAmpl = await (await ethers.getContractFactory('MockXCAmpl'))
+    .connect(deployer)
+    .deploy();
+  xcController = await (await ethers.getContractFactory('MockXCAmpleController'))
+    .connect(deployer)
+    .deploy();
+
+  gateway = await (await ethers.getContractFactory('ChainBridgeXCAmpleGateway'))
+    .connect(deployer)
+    .deploy(bridgeAddress, xcAmpl.address, xcController.address);
+
+  await xcController.updateAMPLEpoch(1);
+  await xcAmpl.updateGlobalAMPLSupply(50000);
+}
+
+describe('ChainBridgeXCAmpleGateway:Initialization', () => {
+  before('setup ChainBridgeXCAmpleGateway contract', setupContracts);
+
+  it('should initialize the references', async function () {
+    expect(await gateway.xcAmpl()).to.eq(xcAmpl.address);
+    expect(await gateway.xcController()).to.eq(xcController.address);
+  });
+
+  it('should set the owner', async function () {
+    expect(await gateway.owner()).to.eq(bridgeAddress);
+  });
+});
+
+describe('ChainBridgeXCAmpleGateway:reportRebase:accessControl', () => {
+  before('setup ChainBridgeXCAmpleGateway contract', setupContracts);
+
+  it('should NOT be callable by non-owner', async function () {
+    await expect(
+      gateway.connect(deployer).reportRebase(1, 50000),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
+  it('should be callable by owner', async function () {
+    await expect(gateway.connect(bridge).reportRebase(1, 50000)).to.not.be
+      .reverted;
+  });
+});
+
+describe('ChainBridgeXCAmpleGateway:reportRebase', () => {
+  before('setup ChainBridgeXCAmpleGateway contract', setupContracts);
+
+  describe('when on-chain supply is different', async function () {
+    it('should emit XCRebaseReportIn', async function () {
+      await expect(gateway.connect(bridge).reportRebase(2, 100000))
+        .to.emit(gateway, 'XCRebaseReportIn')
+        .withArgs(2, 100000, 1, 50000);
+
+      await expect(gateway.connect(bridge).reportRebase(3, 40000))
+        .to.emit(gateway, 'XCRebaseReportIn')
+        .withArgs(3, 40000, 1, 50000);
+    });
+  });
+
+  describe('when on-chain supply is the same', async function () {
+    it('should emit XCRebaseReportIn', async function () {
+      await expect(gateway.connect(bridge).reportRebase(2, 50000))
+        .to.emit(gateway, 'XCRebaseReportIn')
+        .withArgs(2, 50000, 1, 50000);
+    });
+  });
+});
+
+describe('ChainBridgeXCAmpleGateway:mint:accessControl', () => {
+  before('setup ChainBridgeXCAmpleGateway contract', setupContracts);
+
+  it('should NOT be callable by non-owner', async function () {
+    await expect(
+      gateway
+        .connect(deployer)
+        .mint(depositorAddress, recipientAddress, 1001, 50000),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
+  it('should be callable by owner', async function () {
+    await expect(
+      gateway
+        .connect(bridge)
+        .mint(depositorAddress, recipientAddress, 1001, 50000),
+    ).to.not.be.reverted;
+  });
+});
+
+describe('ChainBridgeXCAmpleGateway:mint', () => {
+  before('setup ChainBridgeXCAmpleGateway contract', setupContracts);
+
+  describe('when recorded supply = total supply', function () {
+    it('should emit XCTransferIn', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .mint(depositorAddress, recipientAddress, 1001, 25000),
+      )
+        .to.emit(gateway, 'XCTransferIn')
+        .withArgs(recipientAddress, 25000, 2002, 50000);
+    });
+
+    it('should mint from xcController', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .mint(depositorAddress, recipientAddress, 1001, 25000),
+      )
+        .to.emit(xcController, 'Mint')
+        .withArgs(recipientAddress, 2002);
+    });
+  });
+});
+
+describe('ChainBridgeXCAmpleGateway:mint', () => {
+  before('setup ChainBridgeXCAmpleGateway contract', setupContracts);
+
+  describe('when recorded supply < total supply', function () {
+    it('should emit XCTransferIn', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .mint(depositorAddress, recipientAddress, 1001, 100000),
+      )
+        .to.emit(gateway, 'XCTransferIn')
+        .withArgs(recipientAddress, 100000, 500, 50000);
+    });
+
+    it('should mint from xcController', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .mint(depositorAddress, recipientAddress, 1001, 100000),
+      )
+        .to.emit(xcController, 'Mint')
+        .withArgs(recipientAddress, 500);
+    });
+  });
+});
+
+describe('ChainBridgeXCAmpleGateway:mint', () => {
+  before('setup ChainBridgeXCAmpleGateway contract', setupContracts);
+
+  describe('when recorded supply > total supply', function () {
+    it('should emit XCTransferIn', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .mint(depositorAddress, recipientAddress, 1001, 25000),
+      )
+        .to.emit(gateway, 'XCTransferIn')
+        .withArgs(recipientAddress, 25000, 2002, 50000);
+    });
+
+    it('should mint from xcController', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .mint(depositorAddress, recipientAddress, 1001, 25000),
+      )
+        .to.emit(xcController, 'Mint')
+        .withArgs(recipientAddress, 2002);
+    });
+  });
+});
+
+describe('ChainBridgeXCAmpleGateway:mint', () => {
+  before('setup ChainBridgeXCAmpleGateway contract', setupContracts);
+
+  describe('large numbers', function () {
+    const MAX_SUPPLY = ethers.BigNumber.from(2).pow(128).sub(1);
+    const HALF_MAX_SUPPLY = MAX_SUPPLY.div(2);
+    it('should mint correct number of ampls', async function () {
+      await xcAmpl.updateGlobalAMPLSupply(HALF_MAX_SUPPLY);
+      await expect(
+        gateway
+          .connect(bridge)
+          .mint(
+            depositorAddress,
+            recipientAddress,
+            '100000000000000000000',
+            MAX_SUPPLY,
+          ),
+      )
+        .to.emit(xcController, 'Mint')
+        .withArgs(recipientAddress, '49999999999999999999');
+
+      await xcAmpl.updateGlobalAMPLSupply(MAX_SUPPLY);
+      await expect(
+        gateway
+          .connect(bridge)
+          .mint(
+            depositorAddress,
+            recipientAddress,
+            '100000000000000000000',
+            HALF_MAX_SUPPLY,
+          ),
+      )
+        .to.emit(xcController, 'Mint')
+        .withArgs(recipientAddress, '200000000000000000000');
+
+      await expect(
+        gateway
+          .connect(bridge)
+          .mint(
+            depositorAddress,
+            recipientAddress,
+            '100000000000000000000',
+            MAX_SUPPLY,
+          ),
+      )
+        .to.emit(xcController, 'Mint')
+        .withArgs(recipientAddress, '100000000000000000000');
+    });
+  });
+});
+
+describe('ChainBridgeXCAmpleGateway:validateAndBurn:accessControl', () => {
+  before('setup ChainBridgeXCAmpleGateway contract', async function () {
+    await setupContracts();
+  });
+
+  it('should NOT be callable by non-owner', async function () {
+    await expect(
+      gateway
+        .connect(deployer)
+        .validateAndBurn(depositorAddress, recipientAddress, 1001, 50000),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
+  it('should be callable by owner', async function () {
+    await gateway
+      .connect(bridge)
+      .validateAndBurn(depositorAddress, recipientAddress, 1001, 50000);
+
+    await expect(
+      gateway
+        .connect(bridge)
+        .validateAndBurn(depositorAddress, recipientAddress, 1001, 50000),
+    ).to.not.be.reverted;
+  });
+});
+
+describe('ChainBridgeXCAmpleGateway:validateAndBurn', () => {
+  before('setup ChainBridgeXCAmpleGateway contract', setupContracts);
+
+  describe('when total supply is not consistent', async function () {
+    it('should revert', async function () {
+      await expect(
+        gateway
+          .connect(bridge)
+          .validateAndBurn(depositorAddress, recipientAddress, 1001, 50001),
+      ).to.be.revertedWith(
+        'ChainBridgeXCAmpleGateway: total supply not consistent',
+      );
+    });
+  });
+});
+
+describe('ChainBridgeXCAmpleGateway:validateAndBurn', () => {
+  before('setup ChainBridgeXCAmpleGateway contract', setupContracts);
+
+  it('should emit XCTransferOut', async function () {
+    await expect(
+      gateway
+        .connect(bridge)
+        .validateAndBurn(depositorAddress, recipientAddress, 1001, 50000),
+    )
+      .to.emit(gateway, 'XCTransferOut')
+      .withArgs(depositorAddress, 1001, 50000);
+  });
+
+  it('should burn from xcController', async function () {
+    await expect(
+      gateway
+        .connect(bridge)
+        .validateAndBurn(depositorAddress, recipientAddress, 1001, 50000),
+    )
+      .to.emit(xcController, 'Burn')
+      .withArgs(depositorAddress, 1001);
+  });
+});


### PR DESCRIPTION
Bridge Gateway contracts are pass-through contracts between the AMPL contracts on a given chain and the bridge contract on that chain. Their main role is to handle bridge specific parameter encoding and decoding, and performing data consistency checks before data is sent through the bridge.

We implement 2 such contracts for chain-bridge.

https://github.com/ampleforth/ampl-bridge-solidity/pull/7/commits/366398144d092a75f535be865c78fce9d074aba3

* `AMPLChainBridgeGateway.sol` : Deployed on the master chain. It acts as a pass through between the AMPL policy and token contracts and the ChainBridge `GenericHandler` contract.
* `ChainBridgeXCAmpleGateway.sol`: Deployed on other chains. It acts as a pass through between the XC-Ample controller and XC-Ample token contracts and the ChainBridge `GenericHandler` contract.
