### PR TITLE
Removed approval requirement cross chain transfers from sat chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ sdk/deployments/geth*.json
 console.js
 
 .DS_Store
+
+
+flattened

--- a/.gitignore
+++ b/.gitignore
@@ -73,8 +73,6 @@ coverage.json
 coverage/
 coverageEnv/
 
-.openzeppelin
-
 yarn-error.log
 
 

--- a/.openzeppelin/.gitignore
+++ b/.openzeppelin/.gitignore
@@ -1,0 +1,6 @@
+rinkeby.json
+goerli.json
+unknown-31337.json
+unknown-421611.json
+unknown-97.json
+unknown-80001.json

--- a/.openzeppelin/README.md
+++ b/.openzeppelin/README.md
@@ -1,0 +1,11 @@
+# Chains
+
+Deployed production config files which have been checked in
+
+```
+ethereum -> 1
+bsc -> 56
+polygon -> 137
+avax_cchain -> 43114
+meter -> 82
+```

--- a/.openzeppelin/unknown-137.json
+++ b/.openzeppelin/unknown-137.json
@@ -1,5 +1,10 @@
 {
-  "manifestVersion": "3.1",
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0x7B31EBDE39019d86D4AC8c1cA6bDBe40b8af7d80",
+    "txHash": "0x8957cc80ef7d252e5916d3a9d6338beed6ce16fefe65ee3d7f68f48f5cf500fa"
+  },
+  "proxies": [],
   "impls": {
     "b69313c7b749770a43c8c9c584ac7dcff58a786198ad5b35834ae31a5ee1e7f7": {
       "address": "0x027dbcA046ca156De9622cD1e2D907d375e53aa7",
@@ -227,10 +232,133 @@
           }
         }
       }
+    },
+    "9fdbdeaa989139a9d670235e5f609bcdb3c2fa7794ef01a17dadca4af9ad39a8": {
+      "address": "0x77f94Eb69B56792bBff41df00a56d35ebe39ce33",
+      "txHash": "0xef69707cd23b9a4662d1a06ba6489134d463aef87be150817d90be6c22a53139",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:25"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:30"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "controller",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:26"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:51"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:52"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_decimals",
+            "type": "t_uint8",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:53"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "globalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:56"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonsPerAMPL",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:59"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_totalSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:62"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonBalances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:67"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_allowedXCAmples",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:71"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_nonces",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:86"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
     }
-  },
-  "admin": {
-    "address": "0x7B31EBDE39019d86D4AC8c1cA6bDBe40b8af7d80",
-    "txHash": "0x8957cc80ef7d252e5916d3a9d6338beed6ce16fefe65ee3d7f68f48f5cf500fa"
   }
 }

--- a/.openzeppelin/unknown-137.json
+++ b/.openzeppelin/unknown-137.json
@@ -1,0 +1,236 @@
+{
+  "manifestVersion": "3.1",
+  "impls": {
+    "b69313c7b749770a43c8c9c584ac7dcff58a786198ad5b35834ae31a5ee1e7f7": {
+      "address": "0x027dbcA046ca156De9622cD1e2D907d375e53aa7",
+      "txHash": "0x42c5d5b78118dd74337a966d7d308a4d09f4c5c8ab21f441eaf05a532ee6fc1b",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:24"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:29"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "controller",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:32"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:57"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:58"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_decimals",
+            "type": "t_uint8",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:59"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "globalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:62"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonsPerAMPL",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:65"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_totalSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:68"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonBalances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:73"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_allowedXCAmples",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:77"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_nonces",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:90"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    },
+    "40eb9e28e32b355be6fd86b258899e6af7766f9e2c89a40c25cf9a251cce30eb": {
+      "address": "0x77ca88B795C82026856b8873704443a7944961Af",
+      "txHash": "0x86bd1e6f0fd76ee55bfd2fee6353f11d8e15ed19b3dac45f0862d336fa35454f",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:24"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:29"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "xcAmple",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:56"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "rebaseRelayer",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:60"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "globalAmpleforthEpoch",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:63"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "lastRebaseTimestampSec",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:66"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "nextGlobalAmpleforthEpoch",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:69"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "nextGlobalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:70"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "whitelistedBridgeGateways",
+            "type": "t_mapping(t_address,t_bool)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:73"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          }
+        }
+      }
+    }
+  },
+  "admin": {
+    "address": "0x7B31EBDE39019d86D4AC8c1cA6bDBe40b8af7d80",
+    "txHash": "0x8957cc80ef7d252e5916d3a9d6338beed6ce16fefe65ee3d7f68f48f5cf500fa"
+  }
+}

--- a/.openzeppelin/unknown-43114.json
+++ b/.openzeppelin/unknown-43114.json
@@ -1,0 +1,236 @@
+{
+  "manifestVersion": "3.1",
+  "impls": {
+    "b69313c7b749770a43c8c9c584ac7dcff58a786198ad5b35834ae31a5ee1e7f7": {
+      "address": "0x82E415d7F43D2f56d431124c58221Faa249Ded42",
+      "txHash": "0xcd6926651097b5750168dde76994732d5628973eab5d9ab436345487a9a569ac",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:24"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:29"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "controller",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:32"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:57"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:58"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_decimals",
+            "type": "t_uint8",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:59"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "globalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:62"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonsPerAMPL",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:65"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_totalSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:68"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonBalances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:73"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_allowedXCAmples",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:77"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_nonces",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:90"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    },
+    "40eb9e28e32b355be6fd86b258899e6af7766f9e2c89a40c25cf9a251cce30eb": {
+      "address": "0x4806751f3937120CC12384a7227Fa56Abb36D87c",
+      "txHash": "0x269f3400d31057fd9433903f9589d88075c57369b6b42dc820fde7fb642f903d",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:24"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:29"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "xcAmple",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:56"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "rebaseRelayer",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:60"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "globalAmpleforthEpoch",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:63"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "lastRebaseTimestampSec",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:66"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "nextGlobalAmpleforthEpoch",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:69"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "nextGlobalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:70"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "whitelistedBridgeGateways",
+            "type": "t_mapping(t_address,t_bool)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:73"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          }
+        }
+      }
+    }
+  },
+  "admin": {
+    "address": "0xC9DcF34C93032E4799912ddA196796A35C856576",
+    "txHash": "0x527f4a10c8e1d5ae5ef83cd462be4a12564f3c22c5fb61053835bb8796c165ea"
+  }
+}

--- a/.openzeppelin/unknown-43114.json
+++ b/.openzeppelin/unknown-43114.json
@@ -1,5 +1,10 @@
 {
-  "manifestVersion": "3.1",
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0xC9DcF34C93032E4799912ddA196796A35C856576",
+    "txHash": "0x527f4a10c8e1d5ae5ef83cd462be4a12564f3c22c5fb61053835bb8796c165ea"
+  },
+  "proxies": [],
   "impls": {
     "b69313c7b749770a43c8c9c584ac7dcff58a786198ad5b35834ae31a5ee1e7f7": {
       "address": "0x82E415d7F43D2f56d431124c58221Faa249Ded42",
@@ -227,10 +232,133 @@
           }
         }
       }
+    },
+    "9fdbdeaa989139a9d670235e5f609bcdb3c2fa7794ef01a17dadca4af9ad39a8": {
+      "address": "0xAe192568fADF3E2c0481901669aB5AB1BcD31a1F",
+      "txHash": "0x1ed8bd28cf84d2852d4466c6437239bc2e6b89bf40bd6d3d0311d7c08f025a3c",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:25"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:30"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "controller",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:26"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:51"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:52"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_decimals",
+            "type": "t_uint8",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:53"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "globalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:56"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonsPerAMPL",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:59"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_totalSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:62"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonBalances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:67"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_allowedXCAmples",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:71"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_nonces",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:86"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
     }
-  },
-  "admin": {
-    "address": "0xC9DcF34C93032E4799912ddA196796A35C856576",
-    "txHash": "0x527f4a10c8e1d5ae5ef83cd462be4a12564f3c22c5fb61053835bb8796c165ea"
   }
 }

--- a/.openzeppelin/unknown-56.json
+++ b/.openzeppelin/unknown-56.json
@@ -1,5 +1,10 @@
 {
-  "manifestVersion": "3.1",
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0x47fB203e1d75FB2c518Cd56f3a8094D22A46aF83",
+    "txHash": "0x3504e370d1fdc061df2fdf959f7eba098d20196a366bc44ec42b1682adbc209d"
+  },
+  "proxies": [],
   "impls": {
     "b69313c7b749770a43c8c9c584ac7dcff58a786198ad5b35834ae31a5ee1e7f7": {
       "address": "0x306e5F3aB0B5e972CD68f1C93C8729D6081cac6D",
@@ -227,10 +232,133 @@
           }
         }
       }
+    },
+    "9fdbdeaa989139a9d670235e5f609bcdb3c2fa7794ef01a17dadca4af9ad39a8": {
+      "address": "0x9f2fcDC43e3c07069E6B4F0ADaD8f1cFad9086dB",
+      "txHash": "0x87471487200bea23bcdb22e83d0449dd0ca48f629bf246171ad2e9017c43561a",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:25"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:30"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "controller",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:26"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:51"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:52"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_decimals",
+            "type": "t_uint8",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:53"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "globalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:56"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonsPerAMPL",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:59"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_totalSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:62"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonBalances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:67"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_allowedXCAmples",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:71"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_nonces",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:86"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
     }
-  },
-  "admin": {
-    "address": "0x47fB203e1d75FB2c518Cd56f3a8094D22A46aF83",
-    "txHash": "0x3504e370d1fdc061df2fdf959f7eba098d20196a366bc44ec42b1682adbc209d"
   }
 }

--- a/.openzeppelin/unknown-56.json
+++ b/.openzeppelin/unknown-56.json
@@ -1,0 +1,236 @@
+{
+  "manifestVersion": "3.1",
+  "impls": {
+    "b69313c7b749770a43c8c9c584ac7dcff58a786198ad5b35834ae31a5ee1e7f7": {
+      "address": "0x306e5F3aB0B5e972CD68f1C93C8729D6081cac6D",
+      "txHash": "0x944a4a98065c3202fbadce1c2563bea0fa9e6feb2aff5cbc778e77aecb7a076e",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:24"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:29"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "controller",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:32"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:57"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:58"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_decimals",
+            "type": "t_uint8",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:59"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "globalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:62"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonsPerAMPL",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:65"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_totalSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:68"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonBalances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:73"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_allowedXCAmples",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:77"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_nonces",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:90"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    },
+    "40eb9e28e32b355be6fd86b258899e6af7766f9e2c89a40c25cf9a251cce30eb": {
+      "address": "0x6b64f602690e8D6eb43792C5650ec9FAF512aCa5",
+      "txHash": "0xa5f52b3caf5e0a0da47e7bd663c6e165a54343e4e66e4ef5df98d835de3c810e",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:24"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:29"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "xcAmple",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:56"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "rebaseRelayer",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:60"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "globalAmpleforthEpoch",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:63"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "lastRebaseTimestampSec",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:66"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "nextGlobalAmpleforthEpoch",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:69"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "nextGlobalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:70"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "whitelistedBridgeGateways",
+            "type": "t_mapping(t_address,t_bool)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:73"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          }
+        }
+      }
+    }
+  },
+  "admin": {
+    "address": "0x47fB203e1d75FB2c518Cd56f3a8094D22A46aF83",
+    "txHash": "0x3504e370d1fdc061df2fdf959f7eba098d20196a366bc44ec42b1682adbc209d"
+  }
+}

--- a/.openzeppelin/unknown-82.json
+++ b/.openzeppelin/unknown-82.json
@@ -1,5 +1,10 @@
 {
-  "manifestVersion": "3.1",
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0x14C81A0331c4116804Ab092712c7D3ED4369ee0f",
+    "txHash": "0xce9bba49c161c49b074925e7fd0aed6fd9813a78ad2a5c2d762c607f643151f7"
+  },
+  "proxies": [],
   "impls": {
     "b69313c7b749770a43c8c9c584ac7dcff58a786198ad5b35834ae31a5ee1e7f7": {
       "address": "0x4e28Ed96D27A25A89BF8468C0E0d486B286Bcb83",
@@ -227,10 +232,133 @@
           }
         }
       }
+    },
+    "9fdbdeaa989139a9d670235e5f609bcdb3c2fa7794ef01a17dadca4af9ad39a8": {
+      "address": "0x406a4AD5E9F9D82f41a1C9afeDED61e8F6c4A351",
+      "txHash": "0x807d70703db0c8ea19c07e393cfdbd40774dc36d12bc8101d923f92113160c36",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:25"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:30"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "controller",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:26"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:51"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:52"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_decimals",
+            "type": "t_uint8",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:53"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "globalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:56"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonsPerAMPL",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:59"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_totalSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:62"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonBalances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:67"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_allowedXCAmples",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:71"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_nonces",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:86"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
     }
-  },
-  "admin": {
-    "address": "0x14C81A0331c4116804Ab092712c7D3ED4369ee0f",
-    "txHash": "0xce9bba49c161c49b074925e7fd0aed6fd9813a78ad2a5c2d762c607f643151f7"
   }
 }

--- a/.openzeppelin/unknown-82.json
+++ b/.openzeppelin/unknown-82.json
@@ -1,0 +1,236 @@
+{
+  "manifestVersion": "3.1",
+  "impls": {
+    "b69313c7b749770a43c8c9c584ac7dcff58a786198ad5b35834ae31a5ee1e7f7": {
+      "address": "0x4e28Ed96D27A25A89BF8468C0E0d486B286Bcb83",
+      "txHash": "0x00feb1453ee96d2fa574754e3ff85268dd2c6f4029f9a00aab8b4b84a56c6e08",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:24"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:29"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "controller",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:32"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:57"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:58"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_decimals",
+            "type": "t_uint8",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:59"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "globalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:62"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonsPerAMPL",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:65"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_totalSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:68"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_gonBalances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:73"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_allowedXCAmples",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:77"
+          },
+          {
+            "contract": "XCAmple",
+            "label": "_nonces",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmple.sol:90"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint8": {
+            "label": "uint8"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    },
+    "40eb9e28e32b355be6fd86b258899e6af7766f9e2c89a40c25cf9a251cce30eb": {
+      "address": "0x4e28Ed96D27A25A89BF8468C0E0d486B286Bcb83",
+      "txHash": "0x00feb1453ee96d2fa574754e3ff85268dd2c6f4029f9a00aab8b4b84a56c6e08",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:24"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol:29"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "xcAmple",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:56"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "rebaseRelayer",
+            "type": "t_address",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:60"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "globalAmpleforthEpoch",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:63"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "lastRebaseTimestampSec",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:66"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "nextGlobalAmpleforthEpoch",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:69"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "nextGlobalAMPLSupply",
+            "type": "t_uint256",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:70"
+          },
+          {
+            "contract": "XCAmpleController",
+            "label": "whitelistedBridgeGateways",
+            "type": "t_mapping(t_address,t_bool)",
+            "src": "contracts/satellite-chain/xc-ampleforth/XCAmpleController.sol:73"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          }
+        }
+      }
+    }
+  },
+  "admin": {
+    "address": "0x14C81A0331c4116804Ab092712c7D3ED4369ee0f",
+    "txHash": "0xce9bba49c161c49b074925e7fd0aed6fd9813a78ad2a5c2d762c607f643151f7"
+  }
+}

--- a/contracts/satellite-chain/xc-ampleforth/XCAmple.sol
+++ b/contracts/satellite-chain/xc-ampleforth/XCAmple.sol
@@ -374,6 +374,7 @@ contract XCAmple is IERC20Upgradeable, OwnableUpgradeable {
 
     /**
      * @dev Mint xcAmples to a beneficiary.
+     *      Only callable by the token controller.
      *
      * @param who The address of the beneficiary.
      * @param xcAmpleAmount The amount of xcAmple tokens to be minted.
@@ -390,24 +391,14 @@ contract XCAmple is IERC20Upgradeable, OwnableUpgradeable {
     }
 
     /**
-     * @dev Destroys `xcAmpleAmount` tokens from `who`, deducting from the caller's
-     * allowance.
-     *
-     * This is only callable by the controller, because we only want to support burn for the
-     * interchain-transfer case. Otherwise, AMPL on base chain could become locked in the vault.
-     *
-     * Requirements:
-     *
-     * - the caller must have allowance for ``who``'s tokens of at least
-     * `xcAmpleAmount`.
+     * @dev Destroys `xcAmpleAmount` tokens from `who`.
+     *      Only callable by the token controller.
      *
      * @param who The address of the beneficiary.
      * @param xcAmpleAmount The amount of xcAmple tokens to be burned.
      */
     function burnFrom(address who, uint256 xcAmpleAmount) external onlyController {
         require(who != address(0), "XCAmple: burn address zero address");
-
-        _allowedXCAmples[who][msg.sender] = _allowedXCAmples[who][msg.sender].sub(xcAmpleAmount);
 
         uint256 gonValue = xcAmpleAmount.mul(_gonsPerAMPL);
         _gonBalances[who] = _gonBalances[who].sub(gonValue);

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -20,6 +20,8 @@ require('./tasks/info/ampl');
 require('./tasks/info/chain_bridge');
 require('./tasks/info/cb_ampl_tx');
 
+require('./tasks/upgrade');
+
 module.exports = {
   solidity: {
     compilers: [

--- a/tasks/info/ampl.js
+++ b/tasks/info/ampl.js
@@ -1,4 +1,8 @@
 const ethers = require('ethers');
+const {
+  getAdminAddress,
+  getImplementationAddress,
+} = require('@openzeppelin/upgrades-core');
 
 const { task } = require('../../helpers/tasks');
 const { getEthersProvider } = require('../../helpers/utils');
@@ -208,11 +212,17 @@ task(
         }
 
         console.log('ProxyAdmin:', proxyAdmin.address);
+        console.log('ProxyAdmin:onwer', await proxyAdmin.owner());
         console.log('XCAmple:', xcAmple.address);
         console.log(
-          'XCAmple:implementation',
-          await proxyAdmin.getProxyImplementation(xcAmple.address),
+          'XCAmple:proxyAdmin',
+          await getAdminAddress(provider, xcAmple.address),
         );
+        console.log(
+          'XCAmple:implementation',
+          await getImplementationAddress(provider, xcAmple.address),
+        );
+
         console.log('XCAmple:owner:', await xcAmple.owner());
         console.log('XCAmple:controller:', await xcAmple.controller());
         console.log(
@@ -220,15 +230,17 @@ task(
           toAmplFloatingPt(await xcAmple.totalSupply()),
         );
 
-        console.log('XCAmpleController:', xcAmple.address);
+        console.log('XCAmpleController:', xcAmpleController.address);
+        console.log(
+          'XCAmpleController:proxyAdmin',
+          await getAdminAddress(provider, xcAmpleController.address),
+        );
         console.log(
           'XCAmpleController:implementation',
-          await proxyAdmin.getProxyImplementation(xcAmple.address),
+          await getImplementationAddress(provider, xcAmpleController.address),
         );
-        console.log(
-          'XCAmpleController:owner',
-          await xcAmpleController.owner(),
-        );
+
+        console.log('XCAmpleController:owner', await xcAmpleController.owner());
         console.log(
           'XCAmpleController:xcAmple',
           await xcAmpleController.xcAmple(),

--- a/tasks/upgrade.js
+++ b/tasks/upgrade.js
@@ -1,38 +1,41 @@
 const { types } = require('hardhat/config');
 const { txTask, loadSignerSync, etherscanVerify } = require('../helpers/tasks');
-const { getDeployedContractInstance, upgradeProxyContract } = require('../helpers/contracts');
+const {
+  getDeployedContractInstance,
+  upgradeProxyContract,
+} = require('../helpers/contracts');
 
 txTask(
   'upgrade:xc_ample',
   'Uprades the implementation of the xc-ample ERC-20 contract',
 )
-.addParam('force', 'Skip storage layout verification', false, types.boolean)
-.setAction(async (args, hre) => {
-  const txParams = { gasPrice: args.gasPrice, gasLimit: args.gasLimit };
-  if (txParams.gasPrice == 0) {
-    txParams.gasPrice = await hre.ethers.provider.getGasPrice();
-  }
+  .addParam('force', 'Skip storage layout verification', false, types.boolean)
+  .setAction(async (args, hre) => {
+    const txParams = { gasPrice: args.gasPrice, gasLimit: args.gasLimit };
+    if (txParams.gasPrice == 0) {
+      txParams.gasPrice = await hre.ethers.provider.getGasPrice();
+    }
 
-  const deployer = await loadSignerSync(args, hre.ethers.provider);
-  const deployerAddress = await deployer.getAddress();
+    const deployer = await loadSignerSync(args, hre.ethers.provider);
+    const deployerAddress = await deployer.getAddress();
 
-  console.log('------------------------------------------------------------');
-  console.log('Deployer:', deployerAddress);
-  console.log(txParams);
+    console.log('------------------------------------------------------------');
+    console.log('Deployer:', deployerAddress);
+    console.log(txParams);
 
-  console.log('------------------------------------------------------------');
-  console.log('Upgrading xc-ample contract');
-  const newImpl = await upgradeProxyContract(
-    hre.ethers,
-    hre.network.name,
-    'XCAmple',
-    'xcAmple',
-    deployer,
-    txParams,
-    args.force
-  );
+    console.log('------------------------------------------------------------');
+    console.log('Upgrading xc-ample contract');
+    const newImpl = await upgradeProxyContract(
+      hre.ethers,
+      hre.network.name,
+      'XCAmple',
+      'xcAmple',
+      deployer,
+      txParams,
+      args.force,
+    );
 
-  console.log('------------------------------------------------------------');
-  console.log('Verify on etherscan');
-  await etherscanVerify(hre, newImpl.address);
-});
+    console.log('------------------------------------------------------------');
+    console.log('Verify on etherscan');
+    await etherscanVerify(hre, newImpl.address);
+  });

--- a/tasks/upgrade.js
+++ b/tasks/upgrade.js
@@ -1,0 +1,38 @@
+const { types } = require('hardhat/config');
+const { txTask, loadSignerSync, etherscanVerify } = require('../helpers/tasks');
+const { getDeployedContractInstance, upgradeProxyContract } = require('../helpers/contracts');
+
+txTask(
+  'upgrade:xc_ample',
+  'Uprades the implementation of the xc-ample ERC-20 contract',
+)
+.addParam('force', 'Skip storage layout verification', false, types.boolean)
+.setAction(async (args, hre) => {
+  const txParams = { gasPrice: args.gasPrice, gasLimit: args.gasLimit };
+  if (txParams.gasPrice == 0) {
+    txParams.gasPrice = await hre.ethers.provider.getGasPrice();
+  }
+
+  const deployer = await loadSignerSync(args, hre.ethers.provider);
+  const deployerAddress = await deployer.getAddress();
+
+  console.log('------------------------------------------------------------');
+  console.log('Deployer:', deployerAddress);
+  console.log(txParams);
+
+  console.log('------------------------------------------------------------');
+  console.log('Upgrading xc-ample contract');
+  const newImpl = await upgradeProxyContract(
+    hre.ethers,
+    hre.network.name,
+    'XCAmple',
+    'xcAmple',
+    deployer,
+    txParams,
+    args.force
+  );
+
+  console.log('------------------------------------------------------------');
+  console.log('Verify on etherscan');
+  await etherscanVerify(hre, newImpl.address);
+});

--- a/test/integration/chain_bridge.js
+++ b/test/integration/chain_bridge.js
@@ -259,9 +259,7 @@ async function execXCSend (
         .connect(fromAccount)
         .approve(baseChainAmplContracts.tokenVault.address, amount);
     } else {
-      await amplContractsMap[fromChain].xcAmple
-        .connect(fromAccount)
-        .approve(amplContractsMap[fromChain].xcAmpleController.address, amount);
+      // NO Approval required!
     }
   }
 
@@ -764,7 +762,7 @@ describe('Transfers scenarios', function () {
     });
 
     describe('user does not approve Controller on satellite chain', function () {
-      it('should revert', async function () {
+      it('should NOT revert', async function () {
         // Setup by placing amples on satellite chain
         await checkBalancesAndSupply(
           ['100000', '100000'],
@@ -804,7 +802,7 @@ describe('Transfers scenarios', function () {
             toAmplFixedPt('1'),
             false, // Use existing approval and don't auto-approve.
           ),
-        ).to.be.reverted;
+        ).not.to.be.reverted;
       });
     });
   });

--- a/test/unit/satellite-chain/xc-ampleforth/xc_ample_burn.js
+++ b/test/unit/satellite-chain/xc-ampleforth/xc_ample_burn.js
@@ -36,9 +36,6 @@ describe('XCAmple:burnFrom:accessControl', function () {
     await xcAmple
       .connect(deployer)
       .mint(otherUser.getAddress(), unitTokenAmount);
-    await xcAmple
-      .connect(otherUser)
-      .approve(await deployer.getAddress(), unitTokenAmount);
   });
 
   it('should NOT be callable by other user', async function () {
@@ -74,25 +71,8 @@ describe('XCAmple:burnFrom', () => {
       const mintAmt = toUFrgDenomination('1000000');
       await xcAmple.connect(deployer).mint(otherUser.getAddress(), mintAmt);
       const burnAmt = (await xcAmple.balanceOf(otherUser.getAddress())).add(1);
-      await xcAmple
-        .connect(otherUser)
-        .approve(await deployer.getAddress(), burnAmt);
-
       await expect(
         xcAmple.connect(deployer).burnFrom(otherUser.getAddress(), burnAmt),
-      ).to.be.reverted;
-    });
-  });
-
-  describe('when burn value > approved amount', () => {
-    it('should revert', async function () {
-      const mintAmt = toUFrgDenomination('1000000');
-      await xcAmple.connect(deployer).mint(otherUser.getAddress(), mintAmt);
-      await xcAmple
-        .connect(otherUser)
-        .approve(await deployer.getAddress(), mintAmt.sub(1));
-      await expect(
-        xcAmple.connect(deployer).burnFrom(otherUser.getAddress(), mintAmt),
       ).to.be.reverted;
     });
   });
@@ -104,7 +84,6 @@ describe('XCAmple:burnFrom', () => {
     beforeEach(async function () {
       await xcAmple.connect(deployer).mint(deployer.getAddress(), amt2);
       await xcAmple.connect(deployer).mint(otherUser.getAddress(), amt1);
-      await xcAmple.connect(otherUser).approve(deployer.getAddress(), amt1);
     });
     it('should burn tokens from wallet', async function () {
       await xcAmple.connect(deployer).burnFrom(otherUser.getAddress(), amt1);
@@ -119,16 +98,6 @@ describe('XCAmple:burnFrom', () => {
       expect(await xcAmple.totalSupply()).to.eq(totalAmt);
       await xcAmple.connect(deployer).burnFrom(otherUser.getAddress(), amt1);
       expect(await xcAmple.totalSupply()).to.eq(amt2);
-    });
-    it('should reduce the approved amount', async function () {
-      const allowanceBefore = await xcAmple.allowance(
-        otherUser.getAddress(),
-        deployer.getAddress(),
-      );
-      await xcAmple.connect(deployer).burnFrom(otherUser.getAddress(), amt1);
-      expect(
-        await xcAmple.allowance(otherUser.getAddress(), deployer.getAddress()),
-      ).to.eq(allowanceBefore - amt1);
     });
     it('should log Transfer to zero address', async function () {
       await expect(
@@ -150,7 +119,6 @@ describe('XCAmple:burnFrom', () => {
 
     beforeEach(async function () {
       await xcAmple.connect(deployer).mint(otherUser.getAddress(), mintAmt);
-      await xcAmple.connect(otherUser).approve(deployer.getAddress(), mintAmt);
     });
     it('should burn tokens from wallet', async function () {
       await xcAmple.connect(deployer).burnFrom(otherUser.getAddress(), burnAmt);
@@ -162,16 +130,6 @@ describe('XCAmple:burnFrom', () => {
       expect(await xcAmple.totalSupply()).to.eq(mintAmt);
       await xcAmple.connect(deployer).burnFrom(otherUser.getAddress(), burnAmt);
       expect(await xcAmple.totalSupply()).to.eq(remainingBal);
-    });
-    it('should reduce the approved amount', async function () {
-      const allowanceBefore = await xcAmple.allowance(
-        otherUser.getAddress(),
-        deployer.getAddress(),
-      );
-      await xcAmple.connect(deployer).burnFrom(otherUser.getAddress(), burnAmt);
-      expect(
-        await xcAmple.allowance(otherUser.getAddress(), deployer.getAddress()),
-      ).to.eq(allowanceBefore - burnAmt);
     });
     it('should log Transfer to zero address', async function () {
       await expect(
@@ -193,9 +151,6 @@ describe('XCAmple:burnFrom', () => {
     beforeEach(async function () {
       await xcAmple.rebase(1, MAX_SUPPLY);
       await xcAmple.connect(deployer).mint(otherUser.getAddress(), MAX_SUPPLY);
-      await xcAmple
-        .connect(otherUser)
-        .approve(deployer.getAddress(), MAX_SUPPLY);
     });
 
     it('should burn tokens from wallet', async function () {
@@ -208,16 +163,6 @@ describe('XCAmple:burnFrom', () => {
       expect(await xcAmple.totalSupply()).to.eq(MAX_SUPPLY);
       await xcAmple.connect(deployer).burnFrom(otherUser.getAddress(), burnAmt);
       expect(await xcAmple.totalSupply()).to.eq(remainingBal);
-    });
-    it('should reduce the approved amount', async function () {
-      const allowanceBefore = await xcAmple.allowance(
-        otherUser.getAddress(),
-        deployer.getAddress(),
-      );
-      await xcAmple.connect(deployer).burnFrom(otherUser.getAddress(), burnAmt);
-      expect(
-        await xcAmple.allowance(otherUser.getAddress(), deployer.getAddress()),
-      ).to.eq(allowanceBefore.sub(burnAmt));
     });
     it('should log Transfer to zero address', async function () {
       await expect(


### PR DESCRIPTION
https://github.com/ampleforth/cross-chain-ample/wiki/Transfer-flow-interoperability-between-l2-and-heterogeneous-chains

With the current setup additional consideration to keep in the back of the mind here, the removing `approval` requirement allows the ownership of the XCController (or the upgradability controller) to whitelist their own address and then `mint` / `burn` xcAmple to/from any wallet.

We should consider relinquishing ownership of the XCAmple, XCController (when we feel confident of the bridge and the integration), to guarantee the scantily of the ledger. 

The only "governance" leaver which should exist would be the "rebaseRelayer" (cross-chain orchestrator), which could eventually roll up under forth governance. 